### PR TITLE
Fix: Disable smart quotes and dashes in JSON input field

### DIFF
--- a/AwesomeJson/AwesomeJsonApp.swift
+++ b/AwesomeJson/AwesomeJsonApp.swift
@@ -1,17 +1,27 @@
-//
-//  AwesomeJsonApp.swift
-//  AwesomeJson
-//
-//  Created by 김준성2 (Kim, Junsung) [junsung] on 11/6/24.
-//
-
 import SwiftUI
 
 @main
 struct AwesomeJsonApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate // macOS용 AppDelegate 추가
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onAppear {
+                    // 전체 앱에 대해 스마트 인용부호 및 대시 비활성화
+                    UserDefaults.standard.set(false, forKey: "NSAutomaticQuoteSubstitutionEnabled")
+                    UserDefaults.standard.set(false, forKey: "NSAutomaticDashSubstitutionEnabled")
+                    UserDefaults.standard.synchronize()
+                }
         }
+    }
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // 전체 앱에 대해 스마트 인용부호 및 대시 비활성화 (UserDefaults 설정)
+        UserDefaults.standard.set(false, forKey: "NSAutomaticQuoteSubstitutionEnabled")
+        UserDefaults.standard.set(false, forKey: "NSAutomaticDashSubstitutionEnabled")
+        UserDefaults.standard.synchronize()
     }
 }


### PR DESCRIPTION
# Description
This PR addresses an issue where quotation marks (`"`) and single quotes (`'`) were being automatically converted to smart quotes (`“”` and `‘’`) when entered in the JSON input field. This conversion interfered with JSON formatting and caused validation issues. 

# Problem
- The automatic transformation of quotes and dashes was occurring in the `TextEditor` input field, which led to incorrect JSON format.
- The use of smart quotes (`“”`, `‘’`) was causing errors in JSON parsing.

# Solution
- Disabled smart quotes and dashes by setting `UserDefaults` for `NSAutomaticQuoteSubstitutionEnabled` and `NSAutomaticDashSubstitutionEnabled` to `false`.
- This prevents the automatic substitution of quotes and dashes in the input field, ensuring the integrity of the JSON format.

# Code Changes
The following changes were made to the `AppDelegate`:

```swift
class AppDelegate: NSObject, NSApplicationDelegate {
    func applicationDidFinishLaunching(_ notification: Notification) {
        UserDefaults.standard.set(false, forKey: "NSAutomaticQuoteSubstitutionEnabled")
        UserDefaults.standard.set(false, forKey: "NSAutomaticDashSubstitutionEnabled")
        UserDefaults.standard.synchronize()
    }
}
